### PR TITLE
fix small bug in docker readme and change image name

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,10 @@ $ cd ./modelgym
 ```
 
 ### 2. Running Model Gym In A Container Using DockerHub Image
-To run docker container with official image `modelgym/dockers:latest` from DockerHub repo for using model gym via jupyter you simply run the command:
+To run docker container with official image `modelgym/jupyter:latest` from DockerHub repo for using model gym via jupyter you simply run the command:
 ```sh
 $  docker run -ti --rm  -v "$(pwd)":/src  -p 7777:8888 \
-   modelgym/dockers:latest  bash --login -ci 'jupyter notebook'
+   modelgym/jupyter:latest  bash --login -ci 'jupyter notebook'
 ```
 At first time it downloads container.
 ### <a name="verify-2"></a> 3. Verification If Model Gym Works Correctly

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ $ cd ./modelgym
 ```
 
 ### 2. Running Model Gym In A Container Using DockerHub Image
-To run docker container with official image `anaderi/modelgym:latest` from DockerHub repo for using model gym via jupyter you simply run the command:
+To run docker container with official image `modelgym/dockers:latest` from DockerHub repo for using model gym via jupyter you simply run the command:
 ```sh
 $  docker run -ti --rm  -v "$(pwd)":/src  -p 7777:8888 \
    modelgym/dockers:latest  bash --login -ci 'jupyter notebook'

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ $ cd ./modelgym
 ### 2. Running Model Gym In A Container Using DockerHub Image
 To run docker container with official image `anaderi/modelgym:latest` from DockerHub repo for using model gym via jupyter you simply run the command:
 ```sh
-$  docker run -ti --rm  -v `pwd`:/src  -p 7777:8888 \
-   anaderi/modelgym:latest  bash --login -ci 'jupyter notebook'
+$  docker run -ti --rm  -v "$(pwd)":/src  -p 7777:8888 \
+   modelgym/dockers:latest  bash --login -ci 'jupyter notebook'
 ```
 At first time it downloads container.
 ### <a name="verify-2"></a> 3. Verification If Model Gym Works Correctly


### PR DESCRIPTION
There was small bug in  `docker run` command if directories in path to repository have special names. 
More detailed [here](https://growworkinghard.altervista.org/3-repository-name-must-lowercase-docker-toolbox-error/) . 

Also docker-hub image name was changed.