### PR TITLE
avoid cyclical imports

### DIFF
--- a/modelgym/utils/__init__.py
+++ b/modelgym/utils/__init__.py
@@ -1,5 +1,5 @@
-from modelgym.utils.cat_utils import cat_preprocess_cv, preprocess_cat_cols
 from modelgym.utils.dataset import XYCDataset
+from modelgym.utils.cat_utils import cat_preprocess_cv, preprocess_cat_cols
 from modelgym.utils.util import compare_models_different
 from modelgym.utils.model_space import ModelSpace, process_model_spaces
 from modelgym.utils.hyperopt2skopt import hyperopt2skopt_space


### PR DESCRIPTION
Currently, importing utils breaks things down via cyclical imports.

Here's the traceback:
```
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<ipython-input-2-57f4efb51e1c> in <module>()
----> 1 import modelgym.utils

/opt/conda/lib/python3.6/site-packages/modelgym/utils/__init__.py in <module>()
----> 1 from modelgym.utils.cat_utils import cat_preprocess_cv, preprocess_cat_cols
      2 from modelgym.utils.dataset import XYCDataset
      3 from modelgym.utils.util import compare_models_different
      4 from modelgym.utils.model_space import ModelSpace, process_model_spaces
      5 from modelgym.utils.hyperopt2skopt import hyperopt2skopt_space

/opt/conda/lib/python3.6/site-packages/modelgym/utils/cat_utils.py in <module>()
----> 1 from modelgym.models.learning_task import LearningTask
      2 from collections import defaultdict
      3 
      4 from sklearn import preprocessing
      5 

/opt/conda/lib/python3.6/site-packages/modelgym/models/__init__.py in <module>()
      6 from modelgym.models.rf_model import RFClassifier
      7 from modelgym.models.catboost_model import CtBClassifier, CtBRegressor
----> 8 from modelgym.models.ensemble_model import EnsembleClassifier, EnsembleRegressor

/opt/conda/lib/python3.6/site-packages/modelgym/models/ensemble_model.py in <module>()
     10 from modelgym.models import XGBClassifier, LGBMClassifier, \
     11                             XGBRegressor, LGBMRegressor
---> 12 from modelgym.utils import XYCDataset
     13 
     14 

ImportError: cannot import name 'XYCDataset'
```

This pull fixes the issue.